### PR TITLE
missing \ on messaging product

### DIFF
--- a/config/packages.mk
+++ b/config/packages.mk
@@ -18,13 +18,14 @@ PRODUCT_PACKAGES += \
 
 ifneq ($(TARGET_BUILD_GAPPS),true)
 PRODUCT_PACKAGES += \
+    Apps \
     Etar \
+    GmsCompat \
     Jelly \
     LatinIME \
-    GmsCompat \
-    Seedvault \
-    Apps \
     messaging
+    Seedvault \
+    SetupWizard
 endif
 
 # Include explicitly to work around GMS issues

--- a/config/packages.mk
+++ b/config/packages.mk
@@ -23,7 +23,7 @@ PRODUCT_PACKAGES += \
     GmsCompat \
     Jelly \
     LatinIME \
-    messaging
+    messaging \
     Seedvault \
     SetupWizard
 endif


### PR DESCRIPTION
fix vendor/yaap/config/packages.mk:27: error: missing separator