### PR TITLE
kernel: Use clang-r522817 by default

### DIFF
--- a/config/BoardConfigKernel.mk
+++ b/config/BoardConfigKernel.mk
@@ -93,7 +93,7 @@ ifneq ($(TARGET_KERNEL_CLANG_VERSION),)
     KERNEL_CLANG_VERSION := clang-$(TARGET_KERNEL_CLANG_VERSION)
 else
     # Use the default version of clang if TARGET_KERNEL_CLANG_VERSION hasn't been set by the device config
-    KERNEL_CLANG_VERSION := clang-r487747c
+    KERNEL_CLANG_VERSION := clang-r522817
 endif
 TARGET_KERNEL_CLANG_PATH ?= $(BUILD_TOP)/prebuilts/clang/host/$(HOST_PREBUILT_TAG)/$(KERNEL_CLANG_VERSION)
 


### PR DESCRIPTION
In tag android-15.0.0_r6, clang-r487747c has been removed.

See: https://android.googlesource.com/platform/prebuilts/clang/host/linux-x86/+/5012dae1657aa6625d3add9d903587380a978c94
     https://android.googlesource.com/platform/prebuilts/clang/host/linux-x86/+/refs/tags/android-15.0.0_r6