### PR TITLE
vendor: Disable enroll_layout_truncate_improvement

### DIFF
--- a/release/aconfig/bp2a/com.android.settings.flags/Android.bp
+++ b/release/aconfig/bp2a/com.android.settings.flags/Android.bp
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2024 The LineageOS Project
+// Copyright 2024 Google Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,12 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-aconfig_value_set {
-    name: "aconfig_value_set-yaap-bp2a",
-    values: [
-        "aconfig-values-bp2a-com.android.server.display.feature.flags-all",
-        "aconfig-values-bp2a-com.android.settings.flags-all",
-        "aconfig-values-bp2a-com.android.systemui-all",
-        "aconfig-values-bp2a-android.security-all",
+aconfig_values {
+    name: "aconfig-values-bp2a-com.android.settings.flags-all",
+    package: "com.android.settings.flags",
+    srcs: [
+        "*.textproto",
     ],
 }

--- a/release/aconfig/bp2a/com.android.settings.flags/enroll_layout_truncate_improvement_flag_values.textproto
+++ b/release/aconfig/bp2a/com.android.settings.flags/enroll_layout_truncate_improvement_flag_values.textproto
@@ -1,0 +1,6 @@
+flag_value {
+  package: "com.android.settings.flags"
+  name: "enroll_layout_truncate_improvement"
+  state: DISABLED
+  permission: READ_ONLY
+}


### PR DESCRIPTION
- This fixes the UDFPS overlay for devices with very low UDFPS positioning.