### PR TITLE
vendor: Import tablet specific configs and overlays

### DIFF
--- a/config/common_full_tablet.mk
+++ b/config/common_full_tablet.mk
@@ -1,0 +1,5 @@
+# Inherit mobile full common stuff
+$(call inherit-product, vendor/yaap/config/common_mobile_full.mk)
+
+# Inherit tablet common stuff
+$(call inherit-product, vendor/yaap/config/tablet.mk)

--- a/config/common_full_tablet_wifionly.mk
+++ b/config/common_full_tablet_wifionly.mk
@@ -1,0 +1,7 @@
+# Inherit mobile full common stuff
+$(call inherit-product, vendor/yaap/config/common.mk)
+
+# Inherit tablet common stuff
+$(call inherit-product, vendor/yaap/config/tablet.mk)
+
+$(call inherit-product, vendor/yaap/config/wifionly.mk)

--- a/config/tablet.mk
+++ b/config/tablet.mk
@@ -1,0 +1,8 @@
+$(call inherit-product, $(SRC_TARGET_DIR)/product/large_screen_common.mk)
+
+# Freeform window management
+PRODUCT_COPY_FILES += \
+    frameworks/native/data/etc/android.software.freeform_window_management.xml:$(TARGET_COPY_OUT_PRODUCT)/etc/permissions/android.software.freeform_window_management.xml
+
+# Tablet-specific overlay
+PRODUCT_PACKAGE_OVERLAYS += vendor/yaap/overlay/tablet

--- a/config/wifionly.mk
+++ b/config/wifionly.mk
@@ -1,0 +1,5 @@
+# Apps
+PRODUCT_PACKAGES += \
+    EmergencyInfo
+
+PRODUCT_PACKAGE_OVERLAYS += vendor/yaap/overlay/wifionly

--- a/overlay/tablet/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/tablet/frameworks/base/core/res/res/values/config.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+** Copyright 2009, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <!-- Whether the current device's internal display can host desktop sessions.  -->
+    <bool name="config_canInternalDisplayHostDesktops">true</bool>
+
+    <!-- Whether to enable glanceable hub features on this device. -->
+    <bool name="config_glanceableHubEnabled">true</bool>
+
+    <!-- Whether desktop mode is supported on the current device  -->
+    <bool name="config_isDesktopModeSupported">true</bool>
+</resources>

--- a/overlay/tablet/frameworks/base/packages/SystemUI/res/values/config.xml
+++ b/overlay/tablet/frameworks/base/packages/SystemUI/res/values/config.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+** Copyright 2009, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<!-- These resources are around just to allow their values to be customized
+     for different hardware and product builds. -->
+<resources>
+    <!-- Whether the communal service should be enabled -->
+    <bool name="config_communalServiceEnabled">true</bool>
+
+    <!-- Whether or not to show the UMO on the glanceable hub when media is playing. -->
+    <bool name="config_showUmoOnHub">true</bool>
+
+    <!-- Configuration to swipe to open glanceable hub -->
+    <bool name="config_swipeToOpenGlanceableHub">true</bool>
+</resources>

--- a/overlay/wifionly/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/wifionly/frameworks/base/core/res/res/values/config.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2009 The Android Open Source Project
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+          http://www.apache.org/licenses/LICENSE-2.0
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+
+<!-- These resources are around just to allow their values to be customized
+     for different hardware and product builds.  Do not translate. -->
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <!-- Flag indicating whether the current device is "voice capable".
+         If true, this means that the device supports circuit-switched
+         (i.e. voice) phone calls over the telephony network, and is
+         allowed to display the in-call UI while a cellular voice call is
+         active.  This can be overridden to false for "data only" devices
+         which can't make voice calls and don't support any in-call UI.
+         Note: this flag is subtly different from the
+         PackageManager.FEATURE_TELEPHONY system feature, which is
+         available on *any* device with a telephony radio, even if the
+         device is data-only. -->
+    <bool name="config_voice_capable">false</bool>
+
+    <!-- Flag indicating whether the current device allows sms service.
+         If true, this means that the device supports both sending and
+         receiving sms via the telephony network.
+         This can be overridden to false for "data only" devices
+         which can't send and receive sms message.
+         Note: Disable SMS also disable voicemail waiting sms,
+               cell broadcasting sms, and MMS. -->
+    <bool name="config_sms_capable">false</bool>
+
+    <!-- Flag indicating whether the current device allows data.
+         If true, this means that the device supports data connectivity through
+         the telephony network.
+         This can be overridden to false for devices that support voice and/or sms . -->
+    <bool name="config_mobile_data_capable">false</bool>
+
+    <!-- Number of physical SIM slots on the device. This includes both eSIM and pSIM slots, and
+         is not necessarily the same as the number of phones/logical modems supported by the device.
+         For example, a multi-sim device can have 2 phones/logical modems, but 3 physical slots,
+         or a single SIM device can have 1 phones/logical modems, but 2 physical slots (one eSIM
+         and one pSIM) -->
+    <integer name="config_num_physical_slots">0</integer>
+
+    <!-- Flag indicating device support for EAP SIM, AKA, AKA' -->
+    <bool name="config_eap_sim_based_auth_supported">false</bool>
+
+    <!-- This string array should be overridden by the device to present a list of network
+         attributes.  This is used by the connectivity manager to decide which networks can coexist
+         based on the hardware -->
+    <!-- An Array of "[Connection name],[ConnectivityManager.TYPE_xxxx],
+         [associated radio-type],[priority],[restoral-timer(ms)],[dependencyMet]  -->
+    <!-- the 5th element "resore-time" indicates the number of milliseconds to delay
+         before automatically restore the default connection.  Set -1 if the connection
+         does not require auto-restore. -->
+    <!-- the 6th element indicates boot-time dependency-met value. -->
+    <string-array translatable="false" name="networkAttributes">
+        <item>"wifi,1,1,1,-1,true"</item>
+        <item>"bluetooth,7,7,0,-1,true"</item>
+        <item>"wifi_p2p,13,1,0,-1,true"</item>
+        <item>"ethernet,9,9,2,-1,true"</item>
+    </string-array>
+
+    <!-- This string array should be overridden by the device to present a list of radio
+         attributes.  This is used by the connectivity manager to decide which networks can coexist
+         based on the hardware -->
+    <!-- An Array of "[ConnectivityManager connectionType],
+                      [# simultaneous connection types]"  -->
+    <string-array translatable="false" name="radioAttributes">
+        <item>"1,1"</item>
+        <item>"0,1"</item>
+    </string-array>
+</resources>

--- a/overlay/wifionly/packages/apps/Settings/res/values/config.xml
+++ b/overlay/wifionly/packages/apps/Settings/res/values/config.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright (C) 2019 The Android Open Source Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<resources>
+    <!-- Whether call_volume should be shown or not. -->
+    <bool name="config_show_call_volume">false</bool>
+
+    <!-- Whether data_saver should be shown or not. -->
+    <bool name="config_show_data_saver">false</bool>
+
+    <!-- Whether to show emergency gesture in Settings -->
+    <bool name="config_show_emergency_gesture_settings">false</bool>
+
+    <!-- Whether to show a preference item for mobile plan -->
+    <bool name="config_show_mobile_plan">false</bool>
+
+    <!-- Whether sim related information is visible to the end user. -->
+    <bool name="config_show_sim_info">false</bool>
+</resources>


### PR DESCRIPTION
* Checkout from lineage at https://github.com/LineageOS/android_vendor_lineage/commit/e86febb5311ef160c7e25abcdbec69ae6951ecba

This is a squash commit of the following:

config: tablet: Enable freeform and large screen support for all targets

Change-Id: 18137911f96cf2eb347d8e5012be649ddb01057f8

config: tablet: Deduplicate full tablet configuration

Change-Id: 112cc09d4fca28d063cea76301de287526bfec570

config: Move LatinIME stuff to common_mobile*.mk

Change-Id: 15697e1ccf84972a6a7f76b8c065c575e1ba17ef8

config: Rename mobile-specific configs

Since common full.nk and common mini.mk
mobile-specific, rename then

Change-Id: 12c47fd0688350ar815ccecbff7b453d7fab5d5ea

config: Enable settings large screen optimization for tablets

This was set to true by default prior to U OPR2.
Test: Open settings and notice that dual pane
Layout is back

Change-Id: Ide44ecbe7e30d6b726d9c9358e46c71b35c66250

config: Inherit window_extensions.mk

Instead of explicitly building androidx.window.extensions

Change-Id: 1107ef6ef49eab77d91aa06fe3ade55eeaae83c71

config: Exclude LatinIME dictionaries from RRO overlays

Fixes
https://gitlab.con/LineageOS/issues/and-cid/-/issues/4991

Change-Id: 17722ac86d9d3f02f393b2c120341db5a2b648ff5

config: Include androidx.window.extensions in tablet builds

This enables 2-pane layout in Settings for Android 12L.

Change-Id: 157af5b876c2c33897bf4047a70c10750785a3c76

config: Create makefiles for tablets with telephony support

tablets with telephony have been inheriting from
common full phone.mk, but that's not really proper because such makefile now enables one-handed mode support
(setting prop ro.support_one_handed_mode to true).

Fix this by creating new makefiles that can be used also to include more tablet-specific configs moving forward.

Change-Id: 190c22badb17911ef5e8732990986204778300e6c

Move LatinIME to phone/tablet configs

Move LatinIME & dictionary overlay to exclude
it from TV devices

Change-Id: 1926fe0a2c24ee3d2c807e1f584a37d57f1cbb8b5

cm: Add a tablet_wifionly config

config: tablet: Inherit from large_screen_common.mk

See:
https://android.googlesource.com/platform/build/+/d44b47594236a5ca33434662174d9946deb2fad4

Change-Id: Iebe4ab9f4fdafb9f6a34e50da97b633d0206ad03

config: tablet: Bring back android.software.freeform_window_management feature

Desktop windowing mode depends on it.

Change-Id: Iffdab6b268a3a3ac0fb78027c4900a3fef1eeac5

tablet: Enable desktop windowing mode

This replaces the old freeform window management.

Change-Id: 18711af4d90662252a37bc717590d35651460ad25

config: tablet: Include tablet-specific overlay

Change-Id: 18235aad467d643b06d0ad1dd2c7c0de24bdf4679

config: Ship EmergencyInfo on WiFi only tablets

Change-Id: I89e16f716076d5351949c0bb13f55fc4eaeee4f5

Update Russian translation - tablet overlay

PT-BR: Fix typo

Change-Id: 160d24dc10077a278d7de2503f02712a2dea621e2

Traditional Chinese: Initial translation of tablet overlay

Change-Id: 183f3dcbf32e26a1c3b0b559af994ff096ff87a1b

Merge "Updated Italian translations: tablet overlay" into gingerbread

Updated Italian translations: tablet overlay

Change-Id: 179476fb156bb607b66ab878c22354643d19e621h

Create tablet overlay and set encore to use it

Lot of duplication of work with regards to overlays and tablets. This moves common tablet settings from the individual device trees to a common overlay for a more consistent and easier to manage tablet development. So far only encore has been updated to use this new overlay. Once fully tested, separate changes will be rolled out for other devices.

Change-Id: 10a80368dBeee6256a4cb233895fcedb689100115

PT-BR: Added missing translations

Change-Id: Ieb7adaad6c52f984342c24e37755728efde550d6

overlay: wifionly: Settings: Hide SIM settings

Change-Id: Id521a440e8c7f4182c8fee95090ec007a906c902

overlay: wifionly: Specify that we don't have SIM support

Change-Id: If6a6ba4514f7993a2ed55cf61a15e263bb5cde7b

overlay: wifionly: Mark as WiFi-only

Change-Id: 16c3d5118527903fd0b8a6eb5679dede961e01e9f

overlay: wifionly: Set network and radio attributes

These are specific for WiFi-only capable devices.

Change-Id: 18cbb76030ef334f61d4e15d5e9a6bfcaaeed0bb









Change-Id: I7a3b410c75d8310bc3dd7d2b326e8ad93b294eb5